### PR TITLE
check outgoing payload via req.path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ var mapper = require('./mapper');
 var Floodlight = module.exports = integration('DoubleClick Floodlight')
   .endpoint('https://ad.doubleclick.net/ddm/activity/')
   .channels(['server'])
+  .mapper(mapper)
   .ensure('settings.source')
   .retries(3);
 
@@ -36,8 +37,7 @@ Floodlight.ensure(function(msg){
  * @api private
  */
 
-Floodlight.prototype.track = function(track, done){
-  var payload = mapper.track(track, this.settings);
+Floodlight.prototype.track = function(payload, done){
   // FL wants you to send the parameters as an endpoint delimited by semi-colons rather than get query params
   var endpoint = [
    'dc_rdid=' + payload.dc_rdid,

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "jscs": "1.x",
     "mocha": "2.x",
     "ms": "0.x",
-    "segmentio-integration-tester": "1.x"
+    "segmentio-integration-tester": "1.x",
+    "sinon": "^1.17.5"
   }
 }


### PR DESCRIPTION
checking basically the payload. a little jank since we can't use `query()` to check the query params but actually have to parse the `req.path` in order to ensure that the right endpoint was generated.

@wcjohnson11 
