### PR TITLE
dont send get requests for unmapped events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,14 +12,9 @@ var mapper = require('./mapper');
 var Floodlight = module.exports = integration('DoubleClick Floodlight')
   .endpoint('https://ad.doubleclick.net/ddm/activity/')
   .channels(['server'])
-  .mapper(mapper)
-  .ensure('settings.source')
   .retries(3);
 
-/**
- * Ensure there's an Advertiser Id
- */
-
+// Ensure there's an Advertiser Id and Ad Tracking is enabled
 Floodlight.ensure(function(msg){
   var device = msg.proxy('context.device') || {};
   if (!device.advertisingId) return this.invalid('All calls must have an Advertising Id.');
@@ -37,22 +32,10 @@ Floodlight.ensure(function(msg){
  * @api private
  */
 
-Floodlight.prototype.track = function(payload, done){
-  // FL wants you to send the parameters as an endpoint delimited by semi-colons rather than get query params
-  var endpoint = [
-   'dc_rdid=' + payload.dc_rdid,
-   'src=' + payload.src,
-   'cat=' + payload.cat,
-   'type=' + payload.type,
-   'ord=' + payload.ord,
-   'tag_for_child_directed_treatment=' + payload.tag_for_child_directed_treatment,
-   'dc_lat=' + payload.dc_lat
-  ];
-
-  endpoint = endpoint.join(';');
+Floodlight.prototype.track = function(track, done){
+  var body = mapper.track(track, this.settings);
 
   return this
-    .get(endpoint)
-    .set('User-Agent', payload.userAgent)
+    .get(body)
     .end(this.handle(done));
 };

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -33,6 +33,8 @@ exports.track = function(track, settings){
     }
   });
 
+  if (!mappedEvent) return {};
+
   // Generate random number as shown by Google in their docs
   // https://support.google.com/dcm/partner/answer/2837459?hl=en&ref_topic=3540316
   var cacheBuster = Math.random() * 10000000000000000000;

--- a/test/fixtures/unmapped.json
+++ b/test/fixtures/unmapped.json
@@ -1,0 +1,30 @@
+{
+  "input": {
+    "type": "track",
+    "event": "Pokemon Battle Won",
+    "userId": "user-id",
+    "properties": {
+      "version": 2
+    },
+    "context": {
+      "ip": "10.0.0.2",
+      "app": { "namespace": "com.segment.TestApp", "version": 2 },
+      "device": {
+        "manufacturer": "some-brand",
+        "type": "ios",
+        "advertisingId": "159358",
+        "adTrackingEnabled": true
+      },
+      "network": { "carrier": "some-carrier" },
+      "locale": "en-US",
+      "library": {
+        "name": "analytics-ios"
+      },
+      "referrer": {
+        "type": "iad",
+        "id": "some-id"
+      }
+    }
+  },
+  "output": {}
+}

--- a/test/index.js
+++ b/test/index.js
@@ -80,6 +80,10 @@ describe('DoubleClick Floodlight', function(){
         // ignoring `ord` since it is randomly generated
         test.maps('app-install', settings, { ignored: 'ord' });
       });
+
+      it('should not send unmapped events', function(){
+        test.maps('unmapped', settings);
+      });
     });
   });
 


### PR DESCRIPTION
Currently Doubleclick is erroring on unmapped events. This PR adds a check to stop these errors @hankim813 
